### PR TITLE
fix(input sanitize): Sanitize telegram user's name

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -134,6 +134,7 @@ func onJoin(c tele.Context) error {
 		}
 
 		status.UserFullName = c.Sender().FirstName + " " + c.Sender().LastName
+		status.UserFullName = sanitizeName(status.UserFullName)
 
 		db.Set(kvID, status, minikv.DefaultExpiration)
 

--- a/helper.go
+++ b/helper.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	tele "gopkg.in/tucnak/telebot.v3"
 )
@@ -23,4 +24,23 @@ func stringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+func removeRedundantSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func sanitizeName(s string) string {
+	var result strings.Builder
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if ('a' <= b && b <= 'z') ||
+			('A' <= b && b <= 'Z') ||
+			('0' <= b && b <= '9') ||
+			b == ' ' {
+			result.WriteByte(b)
+		}
+	}
+	clean := removeRedundantSpaces(result.String())
+	return clean
 }


### PR DESCRIPTION
@ammarfaizi2 found a bug that made an incoming telegram user's name
to be treated as a markdown, this are literally security issue that letting
someone to put an active-markdown content inside bot catpcha message

The easiest way to fix this are sanitize JoinStatus.UserFullName to be only
alphanumeric and space characters

Reported-by: Ammar Faizi <ammarfaizi2@gmail.com>
Signed-off-by: Rubi <jihantoro8@gmail.com>